### PR TITLE
Changed Scripts to upload in jcenter automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # JCenter
+build scripts to upload artifacts to jcenter.
+
+From In The Cheese Factory [blog post](http://inthecheesefactory.com/blog/how-to-upload-library-to-jcenter-maven-central-as-dependency/en)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,39 @@
 build scripts to upload artifacts to jcenter.
 
 From In The Cheese Factory [blog post](http://inthecheesefactory.com/blog/how-to-upload-library-to-jcenter-maven-central-as-dependency/en)
+
+# Prerequisites
+Read the blog post linked above first. You need to have following properties, how to get that is described in the post.
+
+# Personal or ownership information
+- `bintrayUser` (A Bintray user name)
+- `bintrayApiKey` (Bintray API key)
+- `bintrayGpgPassword` (A GPG signing mechanism, and it's passphrase)
+- `DEVELOPER_EMAIL` (developer email)
+
+# Library information
+- `GROUP`(Group id of your library)
+- `POM_ARTIFACT_ID` (POM Artifact Id-better to keep it in lowercase)
+- `POM_NAME`
+- `POM_DESCRIPTION`
+- `POM_URL`
+- `POM_DEVELOPER_ID`
+- `POM_DEVELOPER_NAME`
+- `DEVELOPER_EMAIL`
+- `POM_SCM_URL`
+
+# Where should I keep these properties?
+If you put these information in gradle.properties this script can read it easily.
+
+The best place to put Personal or ownership information in system's build.gradle file, so that it does not go with source control.
+For windows it's located at
+C:\Users\{UserName}\.gradle\gradle.properties
+
+For Library information it's better to create gradle.properties in your library module and put all the information there.
+
+# Is there any example?
+Yes, See [android external file writer repository](https://github.com/PrashamTrivedi/AndroidExternalFileWriter) 
+
+# Everything is set, what should I do to upload a file in bintray.
+Just open a command prompt, cd to your library directory and run
+`..\gradlew clean build bintrayUpload`

--- a/bintrayv1.gradle
+++ b/bintrayv1.gradle
@@ -21,13 +21,23 @@ artifacts {
     archives sourcesJar
 }
 
-// Bintray
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
+// Bintray Properties. Gradle can read properties from anywhere
+
+def getBintrayUser(){
+  return hasProperty('bintray.user') ? bintray.user : ""
+}
+
+def getBintrayApiKey(){
+  return hasProperty('bintray.apikey') ? bintray.apikey : ""
+}
+
+def getGpgPassword(){
+  return hasProperty('bintray.gpg.password') ? bintray.gpg.password:  (hasProperty('signing.password') ? signing.password : "")
+}
 
 bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
+    user = getBintrayUser()
+    key = getBintrayApiKey()
 
     configurations = ['archives']
     pkg {
@@ -43,7 +53,7 @@ bintray {
             desc = libraryDescription
             gpg {
                 sign = true //Determines whether to GPG sign the files. The default is false
-                passphrase = properties.getProperty("bintray.gpg.password")
+                passphrase = getGpgPassword()
                 //Optional. The passphrase for GPG signing'
             }
         }

--- a/bintrayv1.gradle
+++ b/bintrayv1.gradle
@@ -1,7 +1,49 @@
 apply plugin: 'com.jfrog.bintray'
 
-version = libraryVersion
+version = VERSION_NAME
 
+
+
+// Bintray Properties. Gradle can read properties from anywhere
+
+def getBintrayUserName(){
+  return hasProperty('bintrayUser') ? bintrayUser : ""
+}
+
+def getApiKey(){
+
+  return hasProperty('bintrayApiKey') ? bintrayApiKey : ""
+}
+
+def getGpgPassword(){
+
+  return hasProperty('bintrayGpgPassword') ? bintrayGpgPassword  : ""
+}
+afterEvaluate{
+bintray {
+    user = getBintrayUserName()
+    key = getApiKey()
+
+    configurations = ['archives']
+    pkg {
+        repo = 'maven'
+        name = POM_NAME
+        desc = POM_DESCRIPTION
+        websiteUrl = POM_URL
+        vcsUrl = POM_SCM_URL
+        licenses = ["Apache-2.0"]
+        publish = true
+        publicDownloadNumbers = true
+        version {
+            desc = POM_DESCRIPTION
+            gpg {
+                sign = true //Determines whether to GPG sign the files. The default is false
+                passphrase = getGpgPassword()
+                //Optional. The passphrase for GPG signing'
+            }
+        }
+    }
+}
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
@@ -20,42 +62,4 @@ artifacts {
     archives javadocJar
     archives sourcesJar
 }
-
-// Bintray Properties. Gradle can read properties from anywhere
-
-def getBintrayUser(){
-  return hasProperty('bintray.user') ? bintray.user : ""
-}
-
-def getBintrayApiKey(){
-  return hasProperty('bintray.apikey') ? bintray.apikey : ""
-}
-
-def getGpgPassword(){
-  return hasProperty('bintray.gpg.password') ? bintray.gpg.password:  (hasProperty('signing.password') ? signing.password : "")
-}
-
-bintray {
-    user = getBintrayUser()
-    key = getBintrayApiKey()
-
-    configurations = ['archives']
-    pkg {
-        repo = bintrayRepo
-        name = bintrayName
-        desc = libraryDescription
-        websiteUrl = siteUrl
-        vcsUrl = gitUrl
-        licenses = allLicenses
-        publish = true
-        publicDownloadNumbers = true
-        version {
-            desc = libraryDescription
-            gpg {
-                sign = true //Determines whether to GPG sign the files. The default is false
-                passphrase = getGpgPassword()
-                //Optional. The passphrase for GPG signing'
-            }
-        }
-    }
 }

--- a/installv1.gradle
+++ b/installv1.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.github.dcendents.android-maven'
 
-group = publishedGroupId                               // Maven Group ID for the artifact
+group = GROUP                               // Maven Group ID for the artifact
 
 install {
     repositories.mavenInstaller {
@@ -8,32 +8,32 @@ install {
         pom {
             project {
                 packaging 'aar'
-                groupId publishedGroupId
-                artifactId artifact
+                groupId GROUP
+                artifactId POM_ARTIFACT_ID
 
                 // Add your description here
-                name libraryName
-                description libraryDescription
-                url siteUrl
+                name POM_NAME
+                description POM_DESCRIPTION
+                url POM_URL
 
                 // Set your license
                 licenses {
                     license {
-                        name licenseName
-                        url licenseUrl
+                        name 'The Apache Software License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
                 developers {
                     developer {
-                        id developerId
-                        name developerName
-                        email developerEmail
+                        id POM_DEVELOPER_ID
+                        name POM_DEVELOPER_NAME
+                        email DEVELOPER_EMAIL
                     }
                 }
                 scm {
-                    connection gitUrl
-                    developerConnection gitUrl
-                    url siteUrl
+                    connection POM_SCM_URL
+                    developerConnection POM_SCM_URL
+                    url POM_URL
 
                 }
             }


### PR DESCRIPTION
Hi as per I have commented in your blog post, I have changed script such a way that it can read properties everywhere, without writing in local.properties, and even does not require ext block.

Here are some changes I have done
- Directly accessing all the properties rather than depending on ext block
- also added afterEvaluate callback where all the properties from build.gradle can be accessed without fail
- Bintray properties had to be renamed because they were not working with dots(.)
- Added readme for better instructions.

I have uploaded couple of projects using it, and added a sample link in readme which refers to my forked repository right now. Once the PR is merged I am willing to change scripts URL.

Thanks
