### PR TITLE
Fixed Travis-CI cann't load local.properties

### DIFF
--- a/bintrayv1.gradle
+++ b/bintrayv1.gradle
@@ -31,7 +31,9 @@ artifacts {
 
 // Bintray
 Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
+if (project.rootProject.file('local.properties').exists()) {
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+}
 
 bintray {
     user = properties.getProperty("bintray.user")


### PR DESCRIPTION
บน **Travis-CI** พบ Error ดังนี้

```
FAILURE: Build failed with an exception.

* Where:

Script '/home/travis/build/first087/Android-License-Fragment/bintray.gradle' line: 34

* What went wrong:

A problem occurred evaluating script.

> /home/travis/build/first087/Android-License-Fragment/local.properties (No such file or directory)
```

ข้อมูลเพิ่มเติม - https://travis-ci.org/first087/Android-License-Fragment/builds/114058450
