### PR TITLE
WIP: Fixed support for linux environment variables

### DIFF
--- a/bintrayv1.gradle
+++ b/bintrayv1.gradle
@@ -34,8 +34,8 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
+    user = properties.getProperty("BINTRAY_USER")
+    key = properties.getProperty("BINTRAY_APIKEY")
 
     configurations = ['archives']
     pkg {


### PR DESCRIPTION
dot (.) is a shell limitation, changing it to underscore.

Stackoverflow reference: https://stackoverflow.com/questions/57110682/travis-ci-environment-variable-key-with-dot?noredirect=1#comment100741182_57110682